### PR TITLE
Bump Spring Boot 3.5.10 -> 3.5.13 to fix CVE-2026-24734

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.5.10'
+	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 	id 'com.github.spotbugs' version '6.1.2'


### PR DESCRIPTION
## Summary
- Bump Spring Boot 3.5.10 → 3.5.13 (latest 3.x stable)
- Fixes CVE-2026-24734 (CVSS > 7) that was failing the OWASP CI check

## Test plan
- [x] `./gradlew dependencyCheckAnalyze` passes (no CVE with CVSS >= 7)
- [x] `./gradlew clean build` passes